### PR TITLE
showProducts

### DIFF
--- a/src/components/show/informers/show.informer.js
+++ b/src/components/show/informers/show.informer.js
@@ -21,12 +21,14 @@ export class ShowInformer {
     `
   }
 
-  async showProducts({tenant, filter}) {
-    const variables = {
+
+  async showProducts({tenant, filter, subdomain}) {
+    const input = {
       tenant: tenant,
-      filter: filter
+      filter: filter,
+      subdomain: subdomain
     }
-    const data = await this.client.fetch(this.showQuery, variables)
+    const data = await this.client.fetch(this.showQuery, {input})
     return data.showProducts && data.showProducts.products || []
   }
 }

--- a/src/components/show/show.js
+++ b/src/components/show/show.js
@@ -15,6 +15,8 @@ export class TemposShowComponent extends Component {
 
     const urlParams = new URLSearchParams(this.global.location.search)
     this.tenant = this.tenant || urlParams.get('tenant') || 'demo'
+    this.subdomain = this.subdomain || urlParams.get('subdomain') 
+    || 'demo-69203cb72376'
     this.limit = this.limit || urlParams.get('limit') || 12
     this.offset = this.offset || urlParams.get('offset') || 0
 
@@ -23,7 +25,7 @@ export class TemposShowComponent extends Component {
   }
 
   reflectedProperties() {
-    return ['tenant', 'limit', 'offset']
+    return ['tenant','subdomain', 'limit', 'offset']
   }
 
   render() {
@@ -62,11 +64,18 @@ export class TemposShowComponent extends Component {
   }
 
   async load() {
+    const domain =
+      (JSON.stringify([['status', '=', `activated`]]))
     const tenant = this.tenant
+    const subdomain = this.subdomain
     const filter = {
-      limit: parseInt(this.limit), offset: parseInt(this.offset) }
+      limit: parseInt(this.limit), 
+      offset: parseInt(this.offset), domain: domain
+    }
   
-    this.products = await this.showInformer.showProducts({tenant, filter})
+    this.products = await this.showInformer.showProducts({
+      tenant, filter, subdomain
+    })
 
     this.render()
 

--- a/tests/components/show/informers/show.informer.spec.js
+++ b/tests/components/show/informers/show.informer.spec.js
@@ -47,10 +47,13 @@ describe('ShowInformer', () => {
 
     const tenant = 'demo'
     const filter= { limit: 6, offset: 0}
-    const products = await informer.showProducts({tenant, filter})
+    const subdomain = 'demo-12252qwe'
+    const products = await informer.showProducts({tenant, filter, subdomain})
 
     expect(products).toEqual([
-      {id: '001', name: 'Ball'},  {id: '002', name: 'Car'}])
+      {id: '001', name: 'Ball'},
+      {id: '002', name: 'Car'}
+    ])
     expect(client.query.replace(/\s/g, '')).toEqual(`
     query ShowProducts($input: ShowProductsInput) {             
       showProducts(input: $input) {                       
@@ -67,8 +70,11 @@ describe('ShowInformer', () => {
       }                                                  
     }`.replace(/\s/g, ''))
     expect(client.variables).toEqual({
-      tenant: 'demo',
-      filter: { limit: 6, offset: 0 }
+      input:{
+        tenant: 'demo',
+        subdomain: 'demo-12252qwe',
+        filter: { limit: 6, offset: 0 }
+      }
     })
   })
 
@@ -76,6 +82,7 @@ describe('ShowInformer', () => {
     const client = informer.client
 
     const tenant = 'demo'
+    const subdomain = 'demo-12252qwe'
     const filter= { limit: 6, offset: 0}
 
     informer.client.result = {
@@ -84,12 +91,15 @@ describe('ShowInformer', () => {
       }
     }
 
-    const products = await informer.showProducts({tenant, filter})
+    const products = await informer.showProducts({tenant, filter, subdomain})
 
     expect(products).toEqual([])
     expect(client.variables).toEqual({
-      tenant: 'demo',
-      filter: { limit: 6, offset: 0 }
+      input:{
+        tenant: 'demo',
+        subdomain: 'demo-12252qwe',
+        filter: { limit: 6, offset: 0 }
+      }
     })
   })
 


### PR DESCRIPTION
Using the ShowProducts to use the Tenant and Subdomain fields to get the products

To use it, the URL is modified by "Site" and in the "show.informer" take the values of the "apiclient" first